### PR TITLE
Bug fixes

### DIFF
--- a/app/models/models.py
+++ b/app/models/models.py
@@ -34,7 +34,7 @@ class Treatment(UserMixin, db.Model):
     __tablename__ = 'treatment'
     id = db.Column(db.Integer, primary_key=True)
     userid = db.Column(db.Integer, nullable=False)
-    timestamp = db.Column(db.Integer, nullable=False)
+    timestamp = db.Column(db.BigInteger, nullable=False)
     lng = db.Column(db.Float)
     lat = db.Column(db.Float)
     treatment = db.Column(db.String(100), nullable=False)


### PR DESCRIPTION
Treatment.timestamp needed a BigInt, updated the model.

Took a crack at un-hardcoding treatment location and making a safe zipcode lookup statement. I tried injecting it this way and I couldn't make it happen, seems OK to me. This returns 400s for not-float latitude or longitude data, using the SQLAlchemy DataError to perform the validation.

http://docs.sqlalchemy.org/en/latest/core/sqlelement.html#sqlalchemy.sql.expression.TextClause.bindparams