### PR TITLE
Fix 405 issue

### DIFF
--- a/app/views/views.py
+++ b/app/views/views.py
@@ -1,5 +1,6 @@
-from flask import render_template, Blueprint, redirect, url_for, flash, g
+from flask import abort, Blueprint, flash, g, render_template, redirect, request, url_for
 from flask_login import LoginManager, UserMixin, current_user, login_user, login_required, logout_user
+from urllib.parse import urlparse, urljoin
 from app.forms.forms import LoginForm
 from app.models.models import User
 
@@ -19,13 +20,21 @@ def login():
         return redirect(url_for('main.capture'))
     form = LoginForm()
     if form.validate_on_submit():
+
         user = User.query.filter_by(username=form.username.data).first()
+
         if user is None or not user.check_password(form.password.data):
             flash('Invalid username or password')
             return redirect(url_for('main.login'))
+
         login_user(user)
         g.user = user
-        return redirect(url_for('main.capture'))
+
+        nexturl = request.args.get('next')
+        if not is_safe_url(nexturl):
+            return abort(400)
+
+        return redirect(nexturl or url_for('main.capture'), code=301)
     return render_template('login.html', title='Sign In', form=form)
 
 @main.route('/logout', methods=['GET'])
@@ -48,7 +57,19 @@ def prediction():
 def dashboard():
     return render_template('my-dashboard.html')
 
-@main.errorhandler(401)
-def page_not_found(e):
-    form = LoginForm()
-    return render_template('login.html', form=form, title='Sign In')
+
+# auth
+
+login_manager = LoginManager()
+
+@login_manager.unauthorized_handler
+def needs_login():
+    return redirect(url_for('main.login', next=url_for(request.endpoint)))
+
+
+# http://flask.pocoo.org/snippets/62/
+def is_safe_url(target):
+    ref_url = urlparse(request.host_url)
+    test_url = urlparse(urljoin(request.host_url, target))
+    return test_url.scheme in ('http', 'https') and \
+           ref_url.netloc == test_url.netloc

--- a/app/views/views.py
+++ b/app/views/views.py
@@ -30,11 +30,11 @@ def login():
         login_user(user)
         g.user = user
 
-        nexturl = request.args.get('next')
-        if not is_safe_url(nexturl):
+        next_ = request.args.get('next')
+        if not is_safe_url(next_):
             return abort(400)
 
-        return redirect(nexturl or url_for('main.capture'), code=301)
+        return redirect(next_ or url_for('main.capture'), code=301)
     return render_template('login.html', title='Sign In', form=form)
 
 @main.route('/logout', methods=['GET'])
@@ -56,16 +56,6 @@ def prediction():
 @main.route('/my-dashboard', methods=['GET'])
 def dashboard():
     return render_template('my-dashboard.html')
-
-
-# auth
-
-login_manager = LoginManager()
-
-@login_manager.unauthorized_handler
-def needs_login():
-    return redirect(url_for('main.login', next=url_for(request.endpoint)))
-
 
 # http://flask.pocoo.org/snippets/62/
 def is_safe_url(target):

--- a/application.py
+++ b/application.py
@@ -8,7 +8,7 @@ from flask import request
 from flask_sslify import SSLify
 
 # views
-from app.views.views import login_manager, main as views_blueprints
+from app.views.views import main as views_blueprints
 
 # forms
 from app.forms.forms import LoginForm
@@ -28,9 +28,8 @@ from app.config import Config
 sslify = SSLify(application)
 
 application.register_blueprint(views_blueprints)
-
-login_manager.init_app(application)
-
+login_manager = LoginManager(application)
+login_manager.login_view = 'main.login'
 
 @application.before_request
 def inject_globals():

--- a/application.py
+++ b/application.py
@@ -8,7 +8,7 @@ from flask import request
 from flask_sslify import SSLify
 
 # views
-from app.views.views import main as views_blueprints
+from app.views.views import login_manager, main as views_blueprints
 
 # forms
 from app.forms.forms import LoginForm
@@ -29,7 +29,6 @@ sslify = SSLify(application)
 
 application.register_blueprint(views_blueprints)
 
-login_manager = LoginManager(application)
 login_manager.init_app(application)
 
 


### PR DESCRIPTION
Instead of rendering the login template on 401s, we redirect to the
login page. The login page will now redirect to ?next after it has
validated the URL is safe and logged the user in. This fixes the issue 
with trying to log in from pages that aren't /login.

This is a pretty standard way of doing this, we're checking against the host header to make sure the URL belongs to us and it serves 400s for bad URLs.

Signed-off-by: Josh Farwell <josh.farwell@gmail.com>